### PR TITLE
Fix NativeModules on Android

### DIFF
--- a/src/api/fs.ts
+++ b/src/api/fs.ts
@@ -4,7 +4,7 @@ import { getNativeModule } from '@api/native';
 
 export type * from '@typings/api/fs';
 
-const FileManager: FileManagerType = getNativeModule('DCDFileManager', 'RTNFileManager');
+const FileManager: FileManagerType = getNativeModule('NativeFileModule', 'DCDFileManager', 'RTNFileManager');
 
 export const Documents = FileManager.DocumentsDirPath;
 

--- a/src/api/native.ts
+++ b/src/api/native.ts
@@ -4,7 +4,7 @@ import { NativeModules, TurboModuleRegistry } from 'react-native';
 
 export type * from '@typings/api/native';
 
-export const BundleInfo: BundleInfoType = NativeModules.NativeClientInfoModule ?? NativeModules.InfoDictionaryManager ?? NativeModules.RTNClientInfoManager;
+export const BundleInfo: BundleInfoType = getNativeModule('NativeClientInfoModule', 'InfoDictionaryManager', 'RTNClientInfoManager');
 export const BundleManager: BundleManagerType = getNativeModule('BundleUpdaterManager');
 export const DeviceInfo: DeviceInfoType = getNativeModule('NativeDeviceModule', 'DCDDeviceManager');
 

--- a/src/api/native.ts
+++ b/src/api/native.ts
@@ -4,9 +4,9 @@ import { NativeModules, TurboModuleRegistry } from 'react-native';
 
 export type * from '@typings/api/native';
 
-export const BundleInfo: BundleInfoType = NativeModules.InfoDictionaryManager ?? NativeModules.RTNClientInfoManager;
+export const BundleInfo: BundleInfoType = NativeModules.NativeClientInfoModule ?? NativeModules.InfoDictionaryManager ?? NativeModules.RTNClientInfoManager;
 export const BundleManager: BundleManagerType = getNativeModule('BundleUpdaterManager');
-export const DeviceInfo: DeviceInfoType = getNativeModule('DCDDeviceManager');
+export const DeviceInfo: DeviceInfoType = getNativeModule('NativeDeviceModule', 'DCDDeviceManager');
 
 export async function reload(instant = true) {
 	if (instant) {


### PR DESCRIPTION
Fixes these errors:
![NativeFileModule](https://github.com/user-attachments/assets/e7331719-bd6f-4e18-a797-9999942fec50)
![NativeClientInfoModule](https://github.com/user-attachments/assets/6b647fe1-8718-4e1f-b2ce-5dd5bae0be36)
