### PR TITLE
fix(themes): properly convert signed ints to hex

### DIFF
--- a/src/utilities/withoutOpacity.ts
+++ b/src/utilities/withoutOpacity.ts
@@ -7,7 +7,7 @@ import { processColor, type ColorValue } from 'react-native';
  * @returns The color provided as a hex string without opacity.
  */
 function withoutOpacity(color: number | ColorValue): string {
-	const processed = processColor(color).toString(16);
+	const processed = (Number(processColor(color)) >>> 0).toString(16);
 
 	return '#' + processed.slice(-6);
 }


### PR DESCRIPTION
processColor returns signed ints representing the colour. without the `>>> 0`converting to unsigned while preserving 2s compliment the function could return insane values.

ex:
#ffffff -> #-1