### PR TITLE
feat(serve): SSE hot-reload stream

### DIFF
--- a/packages/client/scripts/serve/constants.ts
+++ b/packages/client/scripts/serve/constants.ts
@@ -10,8 +10,6 @@ export const DIST_DIR = join(__dirname, '..', '..', 'dist');
 // bakes into the bundle, so the two never drift.
 export const LAN_URL = resolveDevServerUrl();
 
-export const KEEPALIVE_INTERVAL = 5000;
-export const WS_IDLE_TIMEOUT = 60;
 export const WATCH_DEBOUNCE = 100;
 
 /** The name of the built bundle file inside `DIST_DIR`. */
@@ -22,8 +20,6 @@ export default {
 	HOST,
 	DIST_DIR,
 	LAN_URL,
-	KEEPALIVE_INTERVAL,
-	WS_IDLE_TIMEOUT,
 	WATCH_DEBOUNCE,
 	BUNDLE_NAME,
 };

--- a/packages/client/scripts/serve/hot-reload.ts
+++ b/packages/client/scripts/serve/hot-reload.ts
@@ -1,22 +1,22 @@
 import { mkdirSync, readFileSync, watch } from 'node:fs';
-import type { ServerWebSocket } from 'bun';
 import Logger from '@unbound-app/logger';
 import { join } from 'node:path';
 
-import { DIST_DIR, BUNDLE_NAME, WATCH_DEBOUNCE, KEEPALIVE_INTERVAL } from './constants';
+import { DIST_DIR, BUNDLE_NAME, WATCH_DEBOUNCE } from './constants';
 
 const logger = Logger.create('Serve');
 
-const hotClients = new Set<ServerWebSocket>();
+const encoder = new TextEncoder();
+
+const hotClients = new Set<ReadableStreamDefaultController<Uint8Array>>();
 
 let etag = bundleEtag();
 
 /**
- * @description Hashes the built bundle into a non-cryptographic etag. A content hash rather than
- * mtime so a rebuild that produces identical output doesn't reload clients.
+ * @description Hashes the built bundle into an etag, so an identical rebuild doesn't reload clients.
  * @returns The bundle's content hash, or '' if it has not been built yet.
  */
-function bundleEtag(): string {
+export function bundleEtag(): string {
 	try {
 		return Bun.hash(readFileSync(join(DIST_DIR, BUNDLE_NAME))).toString(16);
 	} catch {
@@ -25,77 +25,71 @@ function bundleEtag(): string {
 }
 
 /**
- * @description Sends a JSON frame to a client, dropping it from the registry if the send throws.
- * @param ws The client socket.
- * @param frame The serialised frame to send.
+ * @description Serialises a named SSE event with a JSON payload into wire framing.
+ * @param event The SSE event name (e.g. `reload`).
+ * @param data The payload object, serialised as the `data:` line.
+ * @returns The encoded frame ready to enqueue.
  */
-function send(ws: ServerWebSocket, frame: string) {
+function frame(event: string, data: unknown): Uint8Array {
+	return encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+/**
+ * @description Enqueues a frame to a client, dropping it from the registry if the stream is closed.
+ * @param controller The client's stream controller.
+ * @param payload The encoded frame to enqueue.
+ */
+function send(controller: ReadableStreamDefaultController<Uint8Array>, payload: Uint8Array) {
 	try {
-		ws.send(frame);
+		controller.enqueue(payload);
 	} catch {
-		hotClients.delete(ws);
+		hotClients.delete(controller);
 	}
 }
 
 /** @description Broadcasts the current bundle etag to every connected hot-reload client. */
 function broadcast() {
-	const frame = JSON.stringify({ type: 'reload', etag });
+	const payload = frame('reload', { etag });
 
-	for (const ws of hotClients) send(ws, frame);
+	for (const controller of hotClients) send(controller, payload);
 }
 
 /**
- * @description Registers a connected client and hands it the current etag so a client that missed a
- * build while disconnected catches up.
- * @param ws The newly connected client socket.
+ * @description Handles an SSE connection on `/__hot`: registers the client's stream, sends it the
+ * current etag so it catches up on any build it missed, and deregisters it when the request aborts.
+ * @param req The inbound request.
+ * @returns A streaming `text/event-stream` response.
  */
-export function open(ws: ServerWebSocket) {
-	hotClients.add(ws);
-	logger.info(`Hot-reload client connected (${hotClients.size} total).`);
+export function handleHot(req: Request): Response {
+	let controller: ReadableStreamDefaultController<Uint8Array>;
 
-	ws.send(JSON.stringify({ type: 'reload', etag }));
-}
+	const stream = new ReadableStream<Uint8Array>({
+		start(c) {
+			controller = c;
+			hotClients.add(controller);
+			logger.info(`Hot-reload client connected (${hotClients.size} total).`);
 
-/**
- * @description Removes a disconnected client from the registry.
- * @param ws The disconnected client socket.
- */
-export function close(ws: ServerWebSocket) {
-	hotClients.delete(ws);
-	logger.info(`Hot-reload client disconnected (${hotClients.size} total).`);
-}
+			send(controller, frame('reload', { etag }));
+		},
+		cancel() {
+			hotClients.delete(controller);
+			logger.info(`Hot-reload client disconnected (${hotClients.size} total).`);
+		},
+	});
 
-/**
- * @description Handles an inbound client message. RN does not surface WS protocol pings, so the
- * client speaks JSON ping/pong; reply to its ping and ignore its pong.
- * @param ws The client socket the message came from.
- * @param raw The raw message payload.
- */
-export function message(ws: ServerWebSocket, raw: string | Buffer) {
-	let payload: { type?: string } | null = null;
+	req.signal.addEventListener('abort', () => {
+		hotClients.delete(controller);
+		logger.info(`Hot-reload client disconnected (${hotClients.size} total).`);
+	});
 
-	try {
-		payload = JSON.parse(String(raw));
-	} catch {
-		payload = null;
-	}
-
-	if (payload?.type === 'ping') {
-		ws.send(JSON.stringify({ type: 'pong' }));
-	}
-}
-
-/**
- * @description Starts the app-level keepalive. RN silently drops sockets that look idle, so a JSON
- * ping is sent on an interval to keep the connection warm.
- * @returns The interval handle.
- */
-export function startKeepAlive(): ReturnType<typeof setInterval> {
-	const frame = JSON.stringify({ type: 'ping' });
-
-	return setInterval(() => {
-		for (const ws of hotClients) send(ws, frame);
-	}, KEEPALIVE_INTERVAL);
+	return new Response(stream, {
+		headers: {
+			'Content-Type': 'text/event-stream',
+			'Cache-Control': 'no-cache',
+			Connection: 'keep-alive',
+			'Access-Control-Allow-Origin': '*',
+		},
+	});
 }
 
 /**
@@ -127,4 +121,4 @@ export function watchBundle() {
 	});
 }
 
-export default { open, close, message, startKeepAlive, watchBundle };
+export default { bundleEtag, handleHot, watchBundle };

--- a/packages/client/scripts/serve/index.ts
+++ b/packages/client/scripts/serve/index.ts
@@ -1,6 +1,6 @@
 import Logger from '@unbound-app/logger';
 
-import { PORT, HOST, LAN_URL, DIST_DIR, WS_IDLE_TIMEOUT } from './constants';
+import { PORT, HOST, LAN_URL, DIST_DIR } from './constants';
 import { lanCandidates } from '../dev-host';
 import { serveStatic } from './static';
 import * as hot from './hot-reload';
@@ -8,7 +8,7 @@ import * as hot from './hot-reload';
 const logger = Logger.create('Serve');
 
 /**
- * Starts the dev `serve` server: hosts the hot-reload WebSocket at `/__hot`, serves the built
+ * Starts the dev `serve` server: hosts the hot-reload SSE stream at `/__hot`, serves the built
  * bundle and locale tables from `dist/`, and watches the bundle to broadcast reloads. Returns the
  * `Bun.Server` so an orchestrator can stop it.
  */
@@ -16,33 +16,23 @@ export function startServer() {
 	const server = Bun.serve({
 		port: PORT,
 		hostname: HOST,
-		idleTimeout: WS_IDLE_TIMEOUT,
+		// SSE connections are long-lived; never time them out.
+		idleTimeout: 0,
 		fetch(req) {
 			const pathname = new URL(req.url).pathname;
 
-			if (pathname === '/__hot') {
-				if (server.upgrade(req)) return;
-
-				return new Response('Upgrade failed', { status: 426 });
-			}
+			if (pathname === '/__hot') return hot.handleHot(req);
 
 			return serveStatic(pathname);
 		},
-		websocket: {
-			idleTimeout: WS_IDLE_TIMEOUT,
-			open: hot.open,
-			close: hot.close,
-			message: hot.message,
-		},
 	});
 
-	hot.startKeepAlive();
 	hot.watchBundle();
 
 	logger.info(`Server listening on http://${HOST}:${PORT}/`);
 	logger.info(`Devices on the LAN should connect to: ${LAN_URL}`);
 	logger.info(`Serving files from: ${DIST_DIR}`);
-	logger.info(`Hot-reload socket at ${LAN_URL}/__hot`);
+	logger.info(`Hot-reload SSE stream at ${LAN_URL}/__hot`);
 
 	const candidates = lanCandidates();
 

--- a/packages/client/scripts/serve/static.ts
+++ b/packages/client/scripts/serve/static.ts
@@ -1,9 +1,9 @@
 import Logger from '@unbound-app/logger';
 import { format } from 'date-fns';
 import { join } from 'node:path';
-import { file } from 'bun';
 
-import { DIST_DIR } from './constants';
+import { DIST_DIR, BUNDLE_NAME } from './constants';
+import { bundleEtag } from './hot-reload';
 
 const logger = Logger.create('Serve');
 
@@ -39,8 +39,8 @@ export async function serveStatic(pathname: string): Promise<Response> {
 			return new Response('Forbidden', { status: 403 });
 		}
 
-		const f = file(filePath);
-		const exists = await f.exists();
+		const file = Bun.file(filePath);
+		const exists = await file.exists();
 
 		if (!exists) {
 			logger.warn(`GET ${pathname} - File not found`);
@@ -50,15 +50,22 @@ export async function serveStatic(pathname: string): Promise<Response> {
 		const duration = (performance.now() - startTime).toFixed(2);
 
 		logger.success(
-			`(${format(Date.now(), 'HH:mm:ss')}) GET ${pathname} - ${formatBytes(f.size)} in ${duration}ms`,
+			`(${format(Date.now(), 'HH:mm:ss')}) GET ${pathname} - ${formatBytes(file.size)} in ${duration}ms`,
 		);
 
-		return new Response(f, {
-			headers: {
-				'Content-Type': f.type,
-				'Access-Control-Allow-Origin': '*',
-			},
-		});
+		const headers: Record<string, string> = {
+			'Content-Type': file.type,
+			'Access-Control-Allow-Origin': '*',
+		};
+
+		// Tag the bundle with its content hash - the SSE `reload` carries the same value, so the
+		// device can compare the two. `no-cache` forces the device to always revalidate.
+		if (pathname.slice(1) === BUNDLE_NAME) {
+			headers['ETag'] = `"${bundleEtag()}"`;
+			headers['Cache-Control'] = 'no-cache';
+		}
+
+		return new Response(file, { headers });
 	} catch (error: any) {
 		const duration = (performance.now() - startTime).toFixed(2);
 		logger.error(`GET ${pathname} - Error after ${duration}ms:`, error.message);


### PR DESCRIPTION
## Summary

Replaces the dev server's WebSocket hot-reload channel with **Server-Sent Events** on the same `/__hot` path, and adds an `ETag` to the served bundle so the loader's launch-time conditional GET returns fresh content on reload.

This is the dev-server half of HMR; the loader/native SSE client is already on `loader-ios` (#49).

## Changes

- **`hot-reload.ts`**: SSE client registry (`Set<ReadableStreamDefaultController>`). `handleHot` returns a streaming `text/event-stream` response, registers the client, and sends the current etag on connect so a client that missed a build catches up. `watchBundle` broadcasts a `reload` event (with the new etag) when the bundle content hash changes. The WebSocket handlers and the keepalive ping are removed — SSE connections stay alive on their own.
- **`static.ts`**: sets `ETag` + `Cache-Control: no-cache` on the bundle response, so the device revalidates and gets a 200 with fresh content on reload.
- **`index.ts`**: routes `/__hot` to the SSE handler, sets `idleTimeout: 0` for the long-lived streams, and drops the WebSocket config.
- **`constants.ts`**: removes the now-unused WS/keepalive constants.

## Testing

- `curl -N http://localhost:3000/__hot` holds open and immediately emits `event: reload` with the current etag; a rebuild pushes a new `reload` event.
- `curl -i http://localhost:3000/unbound.bundle` includes an `ETag` matching the SSE etag.
- End-to-end against the iOS loader on a virtual device: enabling HMR opened a persistent SSE connection, and editing a JS source triggered a reload + bundle re-fetch.
- `oxlint`, `oxfmt --check`, and `tsgo --noEmit` all pass on the serve files.