### PR TITLE
fix(api): repair listener cleanup in storage and metro

### DIFF
--- a/packages/client/src/api/metro/index.ts
+++ b/packages/client/src/api/metro/index.ts
@@ -30,6 +30,11 @@ export interface MetroStoreOptions extends MetroSearchOptions {
 	short?: boolean;
 }
 
+/** Search options for {@link findLazy}, adding a `signal` that abandons the wait when aborted. */
+export interface MetroLazySearchOptions extends Omit<MetroSearchOptions, 'lazy' | 'all'> {
+	signal?: AbortSignal;
+}
+
 /** A single entry in a {@link bulk} search: a filter plus its per-item options. */
 export interface MetroBulkItem extends Omit<MetroSearchOptions, 'initial' | 'cache'> {
 	filter: MetroFilter;
@@ -248,30 +253,38 @@ export const off = removeListener;
 /**
  * @description Resolves a module matching `filter`, waiting for it to load if it is not yet present.
  * @param filter The filter to match against.
- * @param options Search options, excluding `lazy` and `all`.
- * @returns The matched module, or a promise that resolves once a matching module is required.
+ * @param options Search options, excluding `lazy` and `all`, plus an optional `signal` to abort the wait.
+ * @returns The matched module, or a promise that resolves once a matching module is required, or
+ * `undefined` if the supplied signal aborts first.
  */
-export function findLazy(
-	filter: MetroFilter,
-	options: Omit<MetroSearchOptions, 'lazy' | 'all'> = {},
-) {
+export function findLazy(filter: MetroFilter, options: MetroLazySearchOptions = {}) {
 	const existing = find(filter, options);
 	if (existing !== void 0) return existing;
 
-	return new Promise((resolve) => {
-		function callback(mdl, id) {
-			if (filter(mdl, id)) {
-				resolve(mdl);
-				remove();
-			}
+	const { signal } = options;
+	if (signal?.aborted) return Promise.resolve(void 0);
 
+	return new Promise((resolve) => {
+		function settle(mdl: any) {
+			remove();
+			signal?.removeEventListener('abort', abort);
+			resolve(mdl);
+		}
+
+		function abort() {
+			settle(void 0);
+		}
+
+		function callback(mdl, id) {
+			if (filter(mdl, id)) return settle(mdl);
 			if (mdl.default && filter(mdl.default, id)) {
-				resolve((options.interop ?? true) ? mdl.default : mdl);
-				remove();
+				return settle((options.interop ?? true) ? mdl.default : mdl);
 			}
 		}
 
 		const remove = addListener(callback);
+
+		signal?.addEventListener('abort', abort, { once: true });
 	});
 }
 

--- a/packages/client/src/api/storage.ts
+++ b/packages/client/src/api/storage.ts
@@ -27,6 +27,7 @@ type EventMap = {
 };
 
 const Events = new EventEmitter<EventMap>();
+const handlers = new Map<(payload: SettingsPayload) => void, (payload: SettingsPayload) => void>();
 
 export const settings = globalThis.UNBOUND_SETTINGS ?? {};
 
@@ -49,9 +50,10 @@ export function addListener(
 		}
 	}
 
+	handlers.set(callback, handler);
 	Events.on('changed', handler);
 
-	return () => Events.off('changed', handler);
+	return () => removeListener(callback);
 }
 
 /**
@@ -59,7 +61,11 @@ export function addListener(
  * @param callback The listener to remove.
  */
 export function removeListener(callback: (payload: SettingsPayload) => void) {
-	Events.off('changed', callback);
+	const handler = handlers.get(callback);
+	if (!handler) return;
+
+	handlers.delete(callback);
+	Events.off('changed', handler);
 }
 
 /**


### PR DESCRIPTION
Two independent cleanup bugs found while scoping hot module reload for plugins. Both matter for reload specifically, since a leaked listener compounds on every cycle.

## `storage.removeListener` was a silent no-op

`addListener` registers an internal `handler` wrapper, but `removeListener` called `Events.off('changed', callback)` with the caller's original function, which was never registered. Every call did nothing.

Wrappers are now tracked against their callback and looked up on removal. The unsubscribe returned by `addListener` delegates to `removeListener` so both paths share one implementation.

This had a live victim: `builtins/debugger.ts:158` loops its tracked listeners through `storage.removeListener` during teardown, so the debugger leaked a storage subscription per connect/teardown cycle. That call site is unchanged and now works as written.

## `findLazy` leaked on no-match

If no module ever satisfied the filter, the promise never settled *and* the listener stayed in `data.listeners`, re-running the filter on every subsequent module require for the lifetime of the app. No timeout, no cancellation.

Added an optional `AbortSignal` through a new `MetroLazySearchOptions`. Aborting removes the listener and resolves `undefined`; an already-aborted signal returns early. Kept as a local option type rather than widening `MetroSearchOptions`, which feeds the whole `Metro*` conditional-type family and the generated SDK.

Also collapsed the resolve path into a single `settle()`. Both the `mdl` and `mdl.default` branches could fire on one invocation, calling `remove()` twice and continuing to filter after resolution.

`findLazy` has no callers in the repo, so the signature change is purely additive.

## Verification

`oxfmt --check`, `oxlint`, and `tsgo --noEmit` all pass (three pre-existing lint warnings remain, none in touched files; no `src/` type errors).

Not exercised against a running device — no device was connected to the debugger bridge. The `findLazy` abort path and the debugger teardown fix are reasoned-correct but untested at runtime, which is worth a look during review.